### PR TITLE
Provides 2 read modes and adapts rate on user request

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,29 @@ ros.import("rtt_rospack")
 runScript(ros.find("rtt_ati_sensor") + "/scripts/ft_sensor.ops")
 ```
 
+
+### OPS file options
+
+Two data reading mode are possible: ***User-based trigger*** and ***Event-based trigger***
+
+By default (no parameters given), ***User-based trigger*** is used with given periodicity
+
+#### User-based trigger
+
+The data is queried at the rate of the component set in the ***setActivity*** command
+
+* optional ***ft_sensor.sample_count = 1***
+* ***ft_sensor.read_mode = 0*** for given periodicity 
+* or ***ft_sensor.read_mode = 3*** to match the periodicity to the NetFT output rate.
+ 
+#### Event-based trigger
+
+The data is output at the rate of the NetFT output rate setting. 
+
+This mode should have the smallest delay in the data due to continuous reading.
+
+* ***ft_sensor.sample_count = 0*** (means infinite number of samples)
+* ***ft_sensor.read_mode = 1*** for current NetFT rate 
+* or ***ft_sensor.read_mode = 2*** to set NetFT to given component period via ***setActivity*** (component period is then modified internally to 0.0).
+
+Note, NetFT rate can only be values that 7000 / integer can reach (7000, 3500, 2333, 1750, 1400, 1167, 1000, ...)

--- a/include/rtt_ati_sensor/rtt_ft_sensor.hpp
+++ b/include/rtt_ati_sensor/rtt_ft_sensor.hpp
@@ -16,6 +16,11 @@
 #include <std_srvs/Empty.h>
 #include <rtt_roscomm/rosservice.h>
 
+#define  RD_MODE_USER_PERIOD  0
+#define  RD_MODE_EVENTBASED   1
+#define  RD_MODE_EVENTBASED_SETRATE   2
+#define  RD_MODE_USER2NETFT 3
+
 /**
  * @brief Namespace containing all rtt related elements. Same as ati namespace for libati_sensor
  *
@@ -26,6 +31,7 @@ namespace rtt_ati{
   *
   */
 static const std::string default_frame = "/ati_ft_link";
+static const int default_sample_count = -1;
 /**
  * @brief This class is a simple RTT wrapper around ati::FTSensor class from libati_sensor.
  *
@@ -79,6 +85,14 @@ protected:
      */
     std::string ip_;
     /**
+     * @brief The read mode of the component
+     * 0: user read rate, do not change anything (default)
+     * 1: event-based read 
+     * 2: event-based read, and change NetFT RDT Output rate to match component activity
+     * 3: user read rate, and change periodicity to match NetFT Output rate
+     */
+    int read_mode_;
+    /**
      * @brief The Orocos output port "wrench"
      *
      */
@@ -122,6 +136,14 @@ protected:
      *
      */
     std::string frame_;
+    /**
+     * @brief The number of samples determines the streaming mode:
+     * -1: use default values
+     * 0: continuous streaming at netft speed
+     * 1: continuous 1 sample query, at user request rate
+     * 2 or more: buffered mode, at user request rate
+     */
+    int sample_count_;
     RTT::os::Mutex lock_;
     bool set_bias_;
 };

--- a/scripts/ft_sensor.ops
+++ b/scripts/ft_sensor.ops
@@ -4,6 +4,9 @@ ros.import("rtt_ati_sensor")
 loadComponent("ft_sensor","rtt_ati::FTSensor")
 
 setActivity("ft_sensor",0.001,10,ORO_SCHED_RT)
+# uncomment for event based update with netft box set at component periodicity
+#ft_sensor.read_mode = 2
+#ft_sensor.sample_count = 0
 
 ft_sensor.configure()
 ft_sensor.start()

--- a/src/rtt_ft_sensor.cpp
+++ b/src/rtt_ft_sensor.cpp
@@ -72,6 +72,19 @@ bool rtt_ati::FTSensor::configureHook(){
 
     this->port_WrenchStamped.setDataSample(this->wrenchStamped);
     configured = ft_sensor_->init(ip_,calibration_index_,ati::command_s::REALTIME);
+    
+    double current_period = this->getActivity()->getPeriod();
+    double current_rate = 0;
+    if (current_period > 0)
+        current_rate = 1 / current_period;
+    int rdt_rate = ft_sensor_->getRDTRate();
+    
+    if (current_rate <= rdt_rate)
+    {
+      RTT::log(RTT::Warning)<<"Current component activity "<< current_rate << " Hz is lower than RDT output rate "<< rdt_rate << \
+      " Hz and will cause lag in the data. Consider changing the component or the netft box settings" <<RTT::endlog();
+    }
+    
     this->wrenchStamped.header.frame_id = frame_;
     return configured;
 }


### PR DESCRIPTION
This PR completely solves #1 and permits to chose the trigger mode of the component: user triggered or event-based. In each mode there can be an automatic matching of the rate on user request.

Event-based trigger uses the continuous sending mode added to the driver and hence depends on https://github.com/kuka-isir/ati_sensor/pull/7 

Event-based should reduce the latency in high speed reading, as it does not require a request at each sample.

Actually here are some interesting numbers 
a 1000 Hz RDT Output rate in event-based mode did not produce a 1000 Hz ros stream but only 998.23 Hz
A 1000 Hz rate in user triggered mode seems to produce a nice steady 1000 Hz ros stream.

However, at 7000 Hz, ros stream is at 6988 Hz with event-based mode when user triggered mode saturates at 2667.132 Hz (even with 7000 Hz activity) probably due to the request and response delays.

all the modes tested but without RTNET.
